### PR TITLE
Use match parameter for filtering instead of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This package provides functions to define time budgets per week and
 display clocked time in a fancy table.
 
 ```elisp
-(setq org-time-budgets '((:title "Business" :tags "+business" :budget "30:00" :block workweek)
-                         (:title "Sideprojects" :tags "+personal+project" :budget "14:00" :block week)
-                         (:title "Practice Music" :tags "+music+practice" :budget "2:55" :block week)
-                         (:title "Exercise" :tags "+exercise" :budget "5:15" :block week)
-                         (:title "Language" :tags "+lang" :budget "5:15" :block week)))
+(setq org-time-budgets '((:title "Business" :match "+business" :budget "30:00" :block workweek)
+                         (:title "Sideprojects" :match "+personal+project" :budget "14:00" :block week)
+                         (:title "Practice Music" :match "+music+practice" :budget "2:55" :block week)
+                         (:title "Exercise" :match "+exercise" :budget "5:15" :block week)
+                         (:title "Language" :match "+lang" :budget "5:15" :block week)))
 ```
 
 Running the function `org-time-budgets-table` will return something like:

--- a/org-time-budgets.el
+++ b/org-time-budgets.el
@@ -44,10 +44,10 @@
 
 See this example:
 
-'((:title \"Business\" :tags \"+business\" :budget \"30:00\")
-  (:title \"Practice Music\" :tags \"+practice+music\" :budget \"4:00\")
-  (:title \"Exercise\" :tags \"+exercise\" :budget \"5:00\"))"
-  :group 'org-pomodoro
+'((:title \"Business\" :match \"+business\" :budget \"30:00\")
+  (:title \"Practice Music\" :match \"+practice+music\" :budget \"4:00\")
+  (:title \"Exercise\" :match \"+exercise\" :budget \"5:00\"))"
+  :group 'org-time-budgets
   :type 'list)
 
 (defvar org-time-budgets-show-budgets t
@@ -115,7 +115,8 @@ See this example:
                                            org-time-budgets))))
     (mapconcat #'(lambda (budget)
                   (let* ((title (plist-get budget :title))
-                         (tags (plist-get budget :tags))
+                         (match (or (plist-get budget :match)
+                                    (plist-get budget :tags))) ;; support for old :tags syntax
                          (block (or (plist-get budget :block) 'week))
 
                          (trange (org-clock-special-range 'thisweek))
@@ -130,13 +131,13 @@ See this example:
                                                (time-subtract tend (current-time)))))
 
                          (range-budget (org-time-budgets-string-to-minutes (plist-get budget :budget)))
-                         (range-clocked (org-time-budgets-time `(:tags ,tags :tstart ,tstart-s :tend ,tend-s)))
+                         (range-clocked (org-time-budgets-time `(:match ,match :tstart ,tstart-s :tend ,tend-s)))
                          (range-bar-length (floor (* (/ (float range-clocked) (float range-budget)) 14)))
 
                          (today-budget (if (eq block 'workweek)
                                            (/ range-budget 5)
                                          (/ range-budget 7)))
-                         (today-clocked (org-time-budgets-time `(:tags ,tags :block today))))
+                         (today-clocked (org-time-budgets-time `(:match ,match :block today))))
                     (format "%s  [%s] %s / %s  [%s] %s / %s"
                              (concat
                               title


### PR DESCRIPTION
`:match` allows tag, todo, category and level matching. All properties
(listed by `org-entry-properties`) can be used. For more info see
"Matching tags and properties" in the Org Manual.

The `:tags` version is kept for backwards compatability.


----

#