### PR TITLE
Use cl-lib macro instead of cl.el one

### DIFF
--- a/org-time-budgets.el
+++ b/org-time-budgets.el
@@ -109,11 +109,11 @@ See this example:
                  (org-agenda-files))))
 
 (defun org-time-budgets-format-block (block)
-  (let ((current (case block
+  (let ((current (cl-case block
                    (day     (org-time-budgets-time `(:match ,match :block today)))
                    (workday (org-time-budgets-time `(:match ,match :block today)))
                    (week    (org-time-budgets-time `(:match ,match :tstart ,tstart-s :tend ,tend-s)))))
-        (budget (case block
+        (budget (cl-case block
                   (day     (/ range-budget 7))
                   (workday (/ range-budget 5))
                   (week    range-budget))))
@@ -134,7 +134,7 @@ See this example:
                          (match (or (plist-get budget :match)
                                     (plist-get budget :tags))) ;; support for old :tags syntax
                          (blocks (or (plist-get budget :blocks)
-                                     (case (plist-get budget :block) ;; support for old :block syntax
+                                     (cl-case (plist-get budget :block) ;; support for old :block syntax
                                        (week '(day week))
                                        (workweek '(workday week)))
                                      '(day week)))


### PR DESCRIPTION
cl.el is deprecated. This also fixes the following byte-compile warnings.

```
org-time-budgets.el:139:41: Warning: the function ‘workweek’ is not known to
    be defined.
org-time-budgets.el:115:21: Warning: the function ‘week’ is not known to be
    defined.
org-time-budgets.el:114:21: Warning: the function ‘workday’ is not known to be
    defined.
org-time-budgets.el:113:21: Warning: the function ‘day’ is not known to be
    defined.
org-time-budgets.el:112:19: Warning: the function ‘case’ is not known to be
    defined.
```